### PR TITLE
hashing once keeping unique state ID in the hash set to avoid hash collision

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -16,6 +16,7 @@ const MAX_OFFSET: u64 = 1 << (MAX_DEPTH + 1);
 
 impl SearchSpace for BinaryTree {
     type State = u64;
+    type StateUniqueId = Self::State;
     type Action = Dir;
     type Iterator = IntoIter<(Self::Action, Self::State)>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(hashmap_hasher)]
 extern crate fnv;
 
 pub mod search;


### PR DESCRIPTION
I have realised that we actually need to keep values in HashSet. This values are needed to avoid hash collisions. They are compared (Eq) when more than one value has the same hash to make 100% false positive free decision.
If we wanted to avoid keeping States (or they unique IDs) in Visited we would need to use Bloom or Cuckoo filter which does not need to keep value but then we would risk skipping some parts of the graph due to false positives.

So here I added another trait that State needs to implement to get it's unique ID which by default is implemented for case when it is the state itself (assuming it is also Hash + Eq + Clone (so it can be stored in the HashSet)). In more "real life" spaces we may have better (smaller) unique state IDs then the state itself.

BTW: try the benchmark :D
