### PR TITLE
Usability tweaks 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-- 1.2.0
+- stable
 - beta
 - nightly
 script:

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,6 +6,7 @@ extern crate test;
 use chappie::search::SearchSpace;
 use test::{Bencher, black_box};
 use std::vec::IntoIter;
+use std::slice::Iter;
 
 enum Dir { Left, Right}
 
@@ -48,18 +49,30 @@ impl BinaryTreeByRef {
     }
 }
 
+struct BinaryTreeByRefIter<'a> {
+    iter: Iter<'a, (Dir, u64)>
+}
+
+impl<'a> Iterator for BinaryTreeByRefIter<'a> {
+    type Item = (&'a Dir, &'a u64);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(&(ref a, ref s)) = self.iter.next() {
+            return Some((a, s));
+        }
+        None
+    }
+}
+
 impl<'a> SearchSpace<'a> for BinaryTreeByRef {
     type State = &'a u64;
     type Action = &'a Dir;
-    type Iterator = IntoIter<(Self::Action, Self::State)>;
+    type Iterator = BinaryTreeByRefIter<'a>;
 
     fn expand(&'a self, state: &Self::State) -> Self::Iterator {
-        self.nodes
-            .iter()
-            .nth(**state as usize).unwrap().iter()
-            .map(|&(ref a, ref s)| (a, s))
-            .collect::<Vec<_>>()
-            .into_iter()
+        BinaryTreeByRefIter {
+            iter: self.nodes[**state as usize].iter()
+        }
     }
 }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -33,5 +33,5 @@ impl<'a> SearchSpace<'a> for BinaryTree {
 #[bench]
 fn dfs(b: &mut Bencher) {
     let tree = BinaryTree;
-    b.iter(|| { black_box(tree.dfs(0, |&g| g == 2)) });
+    b.iter(|| { black_box(tree.dfs(0, |&s| s == 2)) });
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -14,12 +14,12 @@ struct BinaryTree;
 const MAX_DEPTH: u64 = 16;
 const MAX_OFFSET: u64 = 1 << (MAX_DEPTH + 1);
 
-impl SearchSpace for BinaryTree {
+impl<'a> SearchSpace<'a> for BinaryTree {
     type State = u64;
     type Action = Dir;
     type Iterator = IntoIter<(Self::Action, Self::State)>;
 
-    fn expand(&self, state: &Self::State) -> Self::Iterator {
+    fn expand(&'a self, state: &Self::State) -> Self::Iterator {
         let offset = (*state + 2).next_power_of_two();
         if offset >= MAX_OFFSET {
             return vec![].into_iter();
@@ -33,5 +33,5 @@ impl SearchSpace for BinaryTree {
 #[bench]
 fn dfs(b: &mut Bencher) {
     let tree = BinaryTree;
-    b.iter(|| { black_box(tree.dfs(&0, &2)) });
+    b.iter(|| { black_box(tree.dfs(0, |&g| g == 2)) });
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -9,10 +9,10 @@ pub trait SearchSpace<'a> {
 
     fn expand(&'a self, state: &Self::State) -> Self::Iterator;
 
-    fn dfs<G>(&'a self, start: Self::State, is_goal: G) -> Option<Vec<Self::Action>>
-    where G: Fn(&Self::State) -> bool
+    fn dfs<P>(&'a self, start: Self::State, predicate: P) -> Option<Vec<Self::Action>>
+    where P: Fn(&Self::State) -> bool
     {
-        if is_goal(&start) {
+        if predicate(&start) {
             return Some(vec![]);
         }
 
@@ -28,7 +28,7 @@ pub trait SearchSpace<'a> {
                 if visited.contains(&state) {
                     continue;
                 }
-                if is_goal(&state) {
+                if predicate(&state) {
                     return Some(
                         stack.into_iter()
                              .filter_map(|(_, a)| a)
@@ -123,13 +123,13 @@ pub mod tests {
 
         let ts = TestSearch;
 
-        assert_eq!(ts.dfs(0, |&x| x == 0).unwrap(), Vec::<Dir>::new());
-        assert_eq!(ts.dfs(0, |&x| x == 1).unwrap(), vec![Dir::Left]);
-        assert_eq!(ts.dfs(0, |&x| x == 2).unwrap(), vec![Dir::Right]);
-        assert_eq!(ts.dfs(0, |&x| x == 3).unwrap(), vec![Dir::Left, Dir::Left]);
-        assert_eq!(ts.dfs(0, |&x| x == 4).unwrap(), vec![Dir::Left, Dir::Right]);
-        assert_eq!(ts.dfs(2, |&x| x == 2).unwrap(), Vec::<Dir>::new());
-        assert!(ts.dfs(2, |&x| x == 0).is_none());
+        assert_eq!(ts.dfs(0, |&s| s == 0).unwrap(), Vec::<Dir>::new());
+        assert_eq!(ts.dfs(0, |&s| s == 1).unwrap(), vec![Dir::Left]);
+        assert_eq!(ts.dfs(0, |&s| s == 2).unwrap(), vec![Dir::Right]);
+        assert_eq!(ts.dfs(0, |&s| s == 3).unwrap(), vec![Dir::Left, Dir::Left]);
+        assert_eq!(ts.dfs(0, |&s| s == 4).unwrap(), vec![Dir::Left, Dir::Right]);
+        assert_eq!(ts.dfs(2, |&s| s == 2).unwrap(), Vec::<Dir>::new());
+        assert!(ts.dfs(2, |&s| s == 0).is_none());
     }
 
     #[test]
@@ -162,13 +162,13 @@ pub mod tests {
             ]
         };
 
-        assert_eq!(ts.dfs(&0, |&x| *x == 0).unwrap(), Vec::<&Dir>::new());
-        assert_eq!(ts.dfs(&0, |&x| *x == 1).unwrap(), vec![&Dir::Left]);
-        assert_eq!(ts.dfs(&0, |&x| *x == 2).unwrap(), vec![&Dir::Right]);
-        assert_eq!(ts.dfs(&0, |&x| *x == 3).unwrap(), vec![&Dir::Left, &Dir::Left]);
-        assert_eq!(ts.dfs(&0, |&x| *x == 4).unwrap(), vec![&Dir::Left, &Dir::Right]);
-        assert_eq!(ts.dfs(&2, |&x| *x == 2).unwrap(), Vec::<&Dir>::new());
-        assert!(ts.dfs(&2, |&x| *x == 0).is_none());
+        assert_eq!(ts.dfs(&0, |&s| *s == 0).unwrap(), Vec::<&Dir>::new());
+        assert_eq!(ts.dfs(&0, |&s| *s == 1).unwrap(), vec![&Dir::Left]);
+        assert_eq!(ts.dfs(&0, |&s| *s == 2).unwrap(), vec![&Dir::Right]);
+        assert_eq!(ts.dfs(&0, |&s| *s == 3).unwrap(), vec![&Dir::Left, &Dir::Left]);
+        assert_eq!(ts.dfs(&0, |&s| *s == 4).unwrap(), vec![&Dir::Left, &Dir::Right]);
+        assert_eq!(ts.dfs(&2, |&s| *s == 2).unwrap(), Vec::<&Dir>::new());
+        assert!(ts.dfs(&2, |&s| *s == 0).is_none());
     }
 
     #[test]
@@ -183,10 +183,9 @@ pub mod tests {
 
         for start in 0..N_NODES {
             for goal in 0..N_NODES {
-                // need RefCell because the is_goal closure is not allowed to mutate
                 let visited = RefCell::new(HashSet::new());
 
-                if let Some(path) = g.dfs(start, |&g|{ visited.borrow_mut().insert(g); g == goal}) {
+                if let Some(path) = g.dfs(start, |&s|{ visited.borrow_mut().insert(s); s == goal}) {
                     let mut state = start;
                     for action in path {
                         state = g.expand(&state).skip(action).next().unwrap().1;

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::hash::Hash;
 
 pub trait SearchSpace<'a> {
-    type State: Hash + Eq;
+    type State: Hash + Eq + Clone;
     type Action;
     type Iterator: Iterator<Item=(Self::Action, Self::State)>;
 
@@ -25,7 +25,7 @@ pub trait SearchSpace<'a> {
                 Some(&mut (ref mut iter, _)) => iter.next()
             };
             if let Some((action, state)) = next {
-                if visited.contains(&state) {
+                if !visited.insert(state.clone()) {
                     continue;
                 }
                 if predicate(&state) {
@@ -37,7 +37,6 @@ pub trait SearchSpace<'a> {
                     )
                 }
                 stack.push((self.expand(&state), Some(action)));
-                visited.insert(state);
             } else {
                 stack.pop();
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -91,6 +91,7 @@ pub mod tests {
     use std::collections::HashSet;
     use std::marker::PhantomData;
 
+    /*
     struct RandomGraph {
         nodes: Vec<Vec<usize>>
     }
@@ -120,7 +121,7 @@ pub mod tests {
             buf
         }
     }
-/*
+
     impl SearchSpace for RandomGraph {
         type State = usize;
         type Action = usize;
@@ -159,6 +160,7 @@ pub mod tests {
             self.goal == *state
         }
     }
+    */
 
     #[test]
     pub fn test_dfs_simple() {
@@ -167,11 +169,14 @@ pub mod tests {
         #[derive(Debug, PartialEq)]
         enum Dir { Left, Right }
 
-        impl SearchSpace for TestSearch {
+        impl<'a> SearchSpace<'a> for TestSearch {
             type State = i32;
             type Action = Dir;
 
-            fn expand<'b>(&'b self, state: &Self::State) -> Box<Iterator<Item=(&Self::Action, &Self::State)> + 'b> {
+            type BState = i32;
+            type BAction = Dir;
+
+            fn expand(&'a self, state: &Self::State) -> Box<Iterator<Item=(Self::BAction, Self::BState)> + 'a> {
                 Box::new(
                     match *state {
                         0 => vec![(Dir::Left, 1), (Dir::Right, 2)],
@@ -185,14 +190,14 @@ pub mod tests {
 
         let ts = TestSearch;
 
-        assert_eq!(ts.dfs(&0, &0).unwrap(), Vec::<&Dir>::new());
-        assert_eq!(ts.dfs(&0, &1).unwrap(), vec![&Dir::Left]);
-        assert_eq!(ts.dfs(&0, &2).unwrap(), vec![&Dir::Right]);
-        assert_eq!(ts.dfs(&0, &3).unwrap(), vec![&Dir::Left, &Dir::Left]);
-        assert_eq!(ts.dfs(&0, &4).unwrap(), vec![&Dir::Left, &Dir::Right]);
-        assert_eq!(ts.dfs(&2, &2).unwrap(), Vec::<&Dir>::new());
-        assert!(ts.dfs(&2, &0).is_none());
-    }*/
+        assert_eq!(ts.dfs(0, &0).unwrap(), Vec::<Dir>::new());
+        assert_eq!(ts.dfs(0, &1).unwrap(), vec![Dir::Left]);
+        assert_eq!(ts.dfs(0, &2).unwrap(), vec![Dir::Right]);
+        assert_eq!(ts.dfs(0, &3).unwrap(), vec![Dir::Left, Dir::Left]);
+        assert_eq!(ts.dfs(0, &4).unwrap(), vec![Dir::Left, Dir::Right]);
+        assert_eq!(ts.dfs(2, &2).unwrap(), Vec::<Dir>::new());
+        assert!(ts.dfs(2, &0).is_none());
+    }
 
     #[test]
     pub fn test_dfs_simple_by_ref() {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,7 +1,6 @@
 use std::iter::Iterator;
 use std::collections::HashSet;
 use std::hash::Hash;
-use std::borrow::Borrow;
 
 struct Visited<T> {
     hash_set: HashSet<T>
@@ -26,8 +25,9 @@ impl<T> Visited<T> where T: Hash + Eq {
 pub trait SearchSpace<'a> {
     type State: Hash + Eq;
     type Action;
+    type Iterator: Iterator<Item=(Self::Action, Self::State)>;
 
-    fn expand(&'a self, state: &Self::State) -> Box<Iterator<Item=(Self::Action, Self::State)> + 'a>;
+    fn expand(&'a self, state: &Self::State) -> Self::Iterator;
 
     fn dfs<G>(&'a self, start: Self::State, is_goal: G) -> Option<Vec<Self::Action>>
     where G: Fn(&Self::State) -> bool
@@ -37,7 +37,7 @@ pub trait SearchSpace<'a> {
         }
 
         let mut visited = Visited::new();
-        let mut stack = vec![(self.expand(start.borrow()), None)];
+        let mut stack = vec![(self.expand(&start), None)];
 
         loop {
             let next = match stack.last_mut() {
@@ -56,7 +56,7 @@ pub trait SearchSpace<'a> {
                              .collect()
                     )
                 }
-                stack.push((self.expand(state.borrow()), Some(action)));
+                stack.push((self.expand(&state), Some(action)));
                 visited.insert(state);
             } else {
                 stack.pop();
@@ -76,8 +76,7 @@ pub mod tests {
     use std::iter::Enumerate;
     use std::cell::RefCell;
     use std::collections::HashSet;
-
-    /*
+/*
     struct RandomGraph {
         nodes: Vec<Vec<usize>>
     }
@@ -90,7 +89,7 @@ pub mod tests {
             RandomGraph {
                 nodes: rng_e.gen_iter::<usize>().take(n_nodes)
                     .map(|e| rng_n.gen_iter::<usize>().take(e % max_edges)
-                        .map(|n| n % n_nodes).collect()).collect()
+                    .map(|n| n % n_nodes).collect()).collect()
             }
         }
 
@@ -108,7 +107,7 @@ pub mod tests {
         }
     }
 
-    impl SearchSpace for RandomGraph {
+    impl<'a> SearchSpace<'a> for RandomGraph {
         type State = usize;
         type Action = usize;
         type Iterator = Enumerate<IntoIter<usize>>;
@@ -119,31 +118,6 @@ pub mod tests {
             } else {
                 vec![]
             }.into_iter().enumerate()
-        }
-    }
-
-    struct Observer<T> {
-        goal: T,
-        visited: RefCell<Vec<T>>,
-    }
-
-    impl<T> Observer<T> where T: Clone {
-        pub fn new(goal: T) -> Observer<T> {
-            Observer {
-                goal: goal,
-                visited: RefCell::new(vec![])
-            }
-        }
-
-        pub fn visited(&self) -> Vec<T> {
-            self.visited.borrow().clone()
-        }
-    }
-
-    impl<T> SearchGoal<T> for Observer<T> where T: PartialEq + Clone {
-        fn is_goal(&self, state: &T) -> bool {
-            self.visited.borrow_mut().push(state.clone());
-            self.goal == *state
         }
     }
     */
@@ -158,16 +132,15 @@ pub mod tests {
         impl<'a> SearchSpace<'a> for TestSearch {
             type State = i32;
             type Action = Dir;
+            type Iterator = IntoIter<(Self::Action, Self::State)>;
 
-            fn expand(&'a self, state: &Self::State) -> Box<Iterator<Item=(Self::Action, Self::State)> + 'a> {
-                Box::new(
-                    match *state {
-                        0 => vec![(Dir::Left, 1), (Dir::Right, 2)],
-                        1 => vec![(Dir::Left, 3), (Dir::Right, 4)],
-                        2 => vec![(Dir::Left, 2)],
-                        _ => vec![]
-                    }.into_iter()
-                )
+            fn expand(&'a self, state: &Self::State) -> Self::Iterator {
+                match *state {
+                    0 => vec![(Dir::Left, 1), (Dir::Right, 2)],
+                    1 => vec![(Dir::Left, 3), (Dir::Right, 4)],
+                    2 => vec![(Dir::Left, 2)],
+                    _ => vec![]
+                }.into_iter()
             }
         }
 
@@ -194,12 +167,11 @@ pub mod tests {
         impl<'a> SearchSpace<'a> for TestSearch {
             type State = &'a u32;
             type Action = &'a Dir;
+            type Iterator = IntoIter<(Self::Action, Self::State)>;
 
-            fn expand(&'a self, state: &Self::State) -> Box<Iterator<Item=(Self::Action, Self::State)> + 'a> {
-                Box::new(
-                    self.nodes.iter().nth(**state as usize).expect(format!("no state: {}", *state).trim()).iter()
-                    .map(|&(ref a, ref s)| (a, s))
-                )
+            fn expand(&'a self, state: &Self::State) -> Self::Iterator {
+                self.nodes.iter().nth(**state as usize).expect(format!("no state: {}", *state).trim()).iter()
+                .map(|&(ref a, ref s)| (a, s)).collect::<Vec<_>>().into_iter()
             }
         }
 
@@ -222,7 +194,6 @@ pub mod tests {
         assert!(ts.dfs(&2, |&x| *x == 0).is_none());
     }
 
-/*
     #[test]
     pub fn test_dfs_random() {
         const N_NODES: usize = 48;
@@ -230,19 +201,19 @@ pub mod tests {
 
         let g = RandomGraph::new(N_NODES, MAX_EDGES);
 
-        assert!(g.dfs(&N_NODES, &0).is_none());
-        assert!(g.dfs(&0, &N_NODES).is_none());
+        assert!(g.dfs(N_NODES, |&g| g == 0).is_none());
+        assert!(g.dfs(0, |&g| g == N_NODES).is_none());
 
         for start in (0..N_NODES) {
             for goal in (0..N_NODES) {
-                let observer = Observer::new(goal);
-                if let Some(path) = g.dfs(&start, &observer) {
+                if let Some(path) = g.dfs(start, |&g| g == goal) {
                     let mut state = start;
                     for action in path {
                         state = g.expand(&state).skip(action).next().unwrap().1;
                     }
                     assert_eq!(state, goal);
                 } else {
+                    /*
                     let visited: HashSet<_> = observer.visited().iter().cloned().collect();
                     for state in observer.visited() {
                         assert!(!observer.is_goal(&state));
@@ -250,9 +221,9 @@ pub mod tests {
                             assert!(visited.contains(&next_state));
                         }
                     }
+                    */
                 }
             }
         }
     }
-*/
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -204,19 +204,19 @@ pub mod tests {
         enum Dir { Left, Right }
 
         struct TestSearch {
-            nodes: Vec<Vec<(Dir, usize)>>
+            nodes: Vec<Vec<(Dir, u32)>>
         }
 
         impl<'a> SearchSpace<'a> for TestSearch {
-            type State = usize;
+            type State = u32;
             type Action = Dir;
 
-            type BState = &'a usize;
+            type BState = &'a u32;
             type BAction = &'a Dir;
 
             fn expand(&'a self, state: &Self::State) -> Box<Iterator<Item=(Self::BAction, Self::BState)> + 'a> {
                 Box::new(
-                    self.nodes.iter().nth(*state).expect(format!("no state: {}", *state).trim()).iter()
+                    self.nodes.iter().nth(*state as usize).expect(format!("no state: {}", *state).trim()).iter()
                     .map(|&(ref a, ref s)| (a, s))
                 )
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -2,26 +2,6 @@ use std::iter::Iterator;
 use std::collections::HashSet;
 use std::hash::Hash;
 
-struct Visited<T> {
-    hash_set: HashSet<T>
-}
-
-impl<T> Visited<T> where T: Hash + Eq {
-    fn new() -> Visited<T> {
-        Visited {
-            hash_set: HashSet::new()
-        }
-    }
-
-    fn is_visited(&self, value: &T) -> bool {
-        self.hash_set.contains(value)
-    }
-
-    fn insert(&mut self, value: T) -> bool {
-        self.hash_set.insert(value)
-    }
-}
-
 pub trait SearchSpace<'a> {
     type State: Hash + Eq;
     type Action;
@@ -36,7 +16,7 @@ pub trait SearchSpace<'a> {
             return Some(vec![]);
         }
 
-        let mut visited = Visited::new();
+        let mut visited = HashSet::new();
         let mut stack = vec![(self.expand(&start), None)];
 
         loop {
@@ -45,7 +25,7 @@ pub trait SearchSpace<'a> {
                 Some(&mut (ref mut iter, _)) => iter.next()
             };
             if let Some((action, state)) = next {
-                if visited.is_visited(&state) {
+                if visited.contains(&state) {
                     continue;
                 }
                 if is_goal(&state) {

--- a/src/search.rs
+++ b/src/search.rs
@@ -15,6 +15,10 @@ impl<T> Visited<T> where T: Hash + Eq {
         }
     }
 
+    fn is_visited(&self, value: &T) -> bool {
+        self.hash_set.contains(value)
+    }
+
     fn insert(&mut self, value: T) -> bool {
         self.hash_set.insert(value)
     }
@@ -45,7 +49,7 @@ pub trait SearchSpace<'a> {
             return Some(vec![]);
         }
 
-        //let mut visited = Visited::new();
+        let mut visited = Visited::new();
         let mut stack = vec![(self.expand(start.borrow()), None)];
 
         loop {
@@ -54,9 +58,9 @@ pub trait SearchSpace<'a> {
                 Some(&mut (ref mut iter, _)) => iter.next()
             };
             if let Some((action, state)) = next {
-                //if !visited.insert(state) {
-                 //   continue;
-                //}
+                if visited.is_visited(&state) {
+                    continue;
+                }
                 if goal.is_goal(state.borrow()) {
                     return Some(
                         stack.into_iter()
@@ -66,6 +70,7 @@ pub trait SearchSpace<'a> {
                     )
                 }
                 stack.push((self.expand(state.borrow()), Some(action)));
+                visited.insert(state);
             } else {
                 stack.pop();
             }
@@ -203,6 +208,8 @@ pub mod tests {
             type State = usize;
             type Action = Dir;
 
+            // HKT needed to leave lifetime unspecified here and specify it in fn expand as self
+            // lifetime
             type BState = &'a usize;
             type BAction = &'a Dir;
 
@@ -218,7 +225,7 @@ pub mod tests {
             nodes: vec![
                 vec![(Dir::Left, 1), (Dir::Right, 2)],  // 0
                 vec![(Dir::Left, 3), (Dir::Right, 4)],  // 1
-                vec![(Dir::Left, 4)],                   // 2
+                vec![(Dir::Left, 2)],                   // 2
                 vec![],                                 // 3
                 vec![]                                  // 4
             ],

--- a/src/search.rs
+++ b/src/search.rs
@@ -89,7 +89,6 @@ pub mod tests {
     use std::iter::Enumerate;
     use std::cell::RefCell;
     use std::collections::HashSet;
-    use std::marker::PhantomData;
 
     /*
     struct RandomGraph {
@@ -204,17 +203,14 @@ pub mod tests {
         #[derive(Debug, PartialEq, Clone)]
         enum Dir { Left, Right }
 
-        struct TestSearch<'a, T: 'a> {
-            nodes: Vec<Vec<(Dir, usize)>>,
-            phantom: PhantomData<&'a T>
+        struct TestSearch {
+            nodes: Vec<Vec<(Dir, usize)>>
         }
 
-        impl<'a, T> SearchSpace<'a> for TestSearch<'a, T> {
+        impl<'a> SearchSpace<'a> for TestSearch {
             type State = usize;
             type Action = Dir;
 
-            // HKT needed to leave lifetime unspecified here and specify it in fn expand as self
-            // lifetime
             type BState = &'a usize;
             type BAction = &'a Dir;
 
@@ -226,15 +222,14 @@ pub mod tests {
             }
         }
 
-        let ts: TestSearch<usize> = TestSearch {
+        let ts: TestSearch = TestSearch {
             nodes: vec![
                 vec![(Dir::Left, 1), (Dir::Right, 2)],  // 0
                 vec![(Dir::Left, 3), (Dir::Right, 4)],  // 1
                 vec![(Dir::Left, 2)],                   // 2
                 vec![],                                 // 3
                 vec![]                                  // 4
-            ],
-            phantom: PhantomData
+            ]
         };
 
         assert_eq!(ts.dfs(&0, &0).unwrap(), Vec::<&Dir>::new());

--- a/src/search.rs
+++ b/src/search.rs
@@ -134,7 +134,7 @@ pub mod tests {
 
     #[test]
     pub fn test_dfs_simple_by_ref() {
-        #[derive(Debug, PartialEq, Clone)]
+        #[derive(Debug, PartialEq)]
         enum Dir { Left, Right }
 
         struct TestSearch {
@@ -147,18 +147,22 @@ pub mod tests {
             type Iterator = IntoIter<(Self::Action, Self::State)>;
 
             fn expand(&'a self, state: &Self::State) -> Self::Iterator {
-                self.nodes.iter().nth(**state as usize).expect(format!("no state: {}", *state).trim()).iter()
-                .map(|&(ref a, ref s)| (a, s)).collect::<Vec<_>>().into_iter()
+                self.nodes
+                    .iter()
+                    .nth(**state as usize).unwrap().iter()
+                    .map(|&(ref a, ref s)| (a, s))
+                    .collect::<Vec<_>>()
+                    .into_iter()
             }
         }
 
         let ts: TestSearch = TestSearch {
             nodes: vec![
-                vec![(Dir::Left, 1), (Dir::Right, 2)],  // 0
-                vec![(Dir::Left, 3), (Dir::Right, 4)],  // 1
-                vec![(Dir::Left, 2)],                   // 2
-                vec![],                                 // 3
-                vec![]                                  // 4
+                vec![(Dir::Left, 1), (Dir::Right, 2)],
+                vec![(Dir::Left, 3), (Dir::Right, 4)],
+                vec![(Dir::Left, 2)],
+                vec![],
+                vec![]
             ]
         };
 
@@ -185,7 +189,10 @@ pub mod tests {
             for goal in 0..N_NODES {
                 let visited = RefCell::new(HashSet::new());
 
-                if let Some(path) = g.dfs(start, |&s|{ visited.borrow_mut().insert(s); s == goal}) {
+                if let Some(path) = g.dfs(start, |&s| {
+                    visited.borrow_mut().insert(s);
+                    s == goal
+                }) {
                     let mut state = start;
                     for action in path {
                         state = g.expand(&state).skip(action).next().unwrap().1;

--- a/src/search.rs
+++ b/src/search.rs
@@ -6,15 +6,15 @@ struct Visited<T> {
     hash_set: HashSet<T>
 }
 
-impl<T> Visited<T> where T: Hash + Clone + Eq {
+impl<T> Visited<T> where T: Hash + Eq {
     fn new() -> Visited<T> {
         Visited {
             hash_set: HashSet::new()
         }
     }
 
-    fn insert(&mut self, value: &T) -> bool {
-        self.hash_set.insert(value.clone())
+    fn insert(&mut self, value: T) -> bool {
+        self.hash_set.insert(value)
     }
 }
 
@@ -29,7 +29,7 @@ impl<T> SearchGoal<T> for T where T: PartialEq {
 }
 
 pub trait SearchSpace {
-    type State: Hash + Clone + Eq;
+    type State: Hash + Eq;
     type Action;
 
     fn expand<'b>(&'b self, state: &Self::State) -> Box<Iterator<Item=(&Self::Action, &Self::State)> + 'b>;
@@ -41,7 +41,7 @@ pub trait SearchSpace {
         }
 
         let mut visited = Visited::new();
-        let mut stack = vec![(self.expand::<'a>(start), None)];
+        let mut stack = vec![(self.expand(start), None)];
 
         loop {
             let next = match stack.last_mut() {
@@ -49,10 +49,10 @@ pub trait SearchSpace {
                 Some(&mut (ref mut iter, _)) => iter.next()
             };
             if let Some((action, state)) = next {
-                if !visited.insert(&state) {
+                if !visited.insert(state) {
                     continue;
                 }
-                if goal.is_goal(&state) {
+                if goal.is_goal(state) {
                     return Some(
                         stack.into_iter()
                              .filter_map(|(_, a)| a)
@@ -60,7 +60,7 @@ pub trait SearchSpace {
                              .collect()
                     )
                 }
-                stack.push((self.expand(&state), Some(action)));
+                stack.push((self.expand(state), Some(action)));
             } else {
                 stack.pop();
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -69,14 +69,12 @@ pub trait SearchSpace<'a> {
 pub mod tests {
     use super::SearchSpace;
     use std::vec::IntoIter;
-    use std::slice::Iter;
-    use std::iter::Map;
     use rand::chacha::ChaChaRng;
     use rand::Rng;
     use std::iter::Enumerate;
     use std::cell::RefCell;
     use std::collections::HashSet;
-/*
+
     struct RandomGraph {
         nodes: Vec<Vec<usize>>
     }
@@ -120,7 +118,6 @@ pub mod tests {
             }.into_iter().enumerate()
         }
     }
-    */
 
     #[test]
     pub fn test_dfs_simple() {
@@ -204,24 +201,24 @@ pub mod tests {
         assert!(g.dfs(N_NODES, |&g| g == 0).is_none());
         assert!(g.dfs(0, |&g| g == N_NODES).is_none());
 
-        for start in (0..N_NODES) {
-            for goal in (0..N_NODES) {
-                if let Some(path) = g.dfs(start, |&g| g == goal) {
+        for start in 0..N_NODES {
+            for goal in 0..N_NODES {
+                // need RefCell because the is_goal closure is not allowed to mutate
+                let visited = RefCell::new(HashSet::new());
+
+                if let Some(path) = g.dfs(start, |&g|{ visited.borrow_mut().insert(g); g == goal}) {
                     let mut state = start;
                     for action in path {
                         state = g.expand(&state).skip(action).next().unwrap().1;
                     }
                     assert_eq!(state, goal);
                 } else {
-                    /*
-                    let visited: HashSet<_> = observer.visited().iter().cloned().collect();
-                    for state in observer.visited() {
-                        assert!(!observer.is_goal(&state));
+                    for state in visited.borrow().iter() {
+                        assert!(*state != goal);
                         for (_, next_state) in g.expand(&state) {
-                            assert!(visited.contains(&next_state));
+                            assert!(visited.borrow().contains(&next_state));
                         }
                     }
-                    */
                 }
             }
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -89,7 +89,7 @@ pub mod tests {
         type Action = usize;
         type Iterator = Enumerate<IntoIter<usize>>;
 
-        fn expand(&self, state: &usize) -> Self::Iterator {
+        fn expand(&self, state: &Self::State) -> Self::Iterator {
             if *state < self.nodes.len() {
                 self.nodes[*state].clone()
             } else {
@@ -181,8 +181,8 @@ pub mod tests {
 
         let g = RandomGraph::new(N_NODES, MAX_EDGES);
 
-        assert!(g.dfs(N_NODES, |&g| g == 0).is_none());
-        assert!(g.dfs(0, |&g| g == N_NODES).is_none());
+        assert!(g.dfs(N_NODES, |&s| s == 0).is_none());
+        assert!(g.dfs(0, |&s| s == N_NODES).is_none());
 
         for start in 0..N_NODES {
             for goal in 0..N_NODES {

--- a/src/search.rs
+++ b/src/search.rs
@@ -205,20 +205,13 @@ pub mod tests {
             }
         }
 
-        /*
-         *          0
-         *      1       2
-         *    3   4
-         *
-         */
         let ts = TestSearch {
             nodes: vec![
                 vec![(Dir::Left, 1), (Dir::Right, 2)],  // 0
                 vec![(Dir::Left, 3), (Dir::Right, 4)],  // 1
                 vec![(Dir::Left, 2)],                   // 2
                 vec![],                                 // 3
-                vec![],                                 // 4
-                vec![]                                  // 5
+                vec![]                                  // 4
             ]
         };
 
@@ -229,7 +222,6 @@ pub mod tests {
         assert_eq!(ts.dfs(&0, &4).unwrap(), vec![&Dir::Left, &Dir::Right]);
         assert_eq!(ts.dfs(&2, &2).unwrap(), Vec::<&Dir>::new());
         assert!(ts.dfs(&2, &0).is_none());
-        assert!(ts.dfs(&5, &0).is_none());
     }
 
 /*


### PR DESCRIPTION
This PR brings some smaller changes to usability of the library.
I can prepare more specialised PR if only selected features are going to be merged.
- added life time to SearchSpace - this allows user to use ptr-& types for Action and State without need for PhantomData or HKT support at cost of having to put <'a> in the impl and expand signatures
- using Fn(&Self::State) -> bool predicate instead of SearchGoal - this make it to look&feel more like Iterator API; eliminate need for Observer impl for random tree test but you need to use tiny closure instead of blanket impl
- removed Visited struct as in current state having it does not bring any benefits
- added two more benchmarks that use in memory binary tree representation and allow comparison of search performance when Action and State are passed by value or by reference

Here are benchmarks against current master branch:

master:
test dfs ... bench:  13,254,952 ns/iter (+/- 5,345,397)

this:
test dfs        ... bench:  13,822,033 ns/iter (+/- 4,594,586)
test dfs_by_ref ... bench:  23,668,700 ns/iter (+/- 3,307,109)
test dfs_by_val ... bench:  24,426,540 ns/iter (+/- 3,749,642)

master (no visited):
test dfs ... bench:   2,135,067 ns/iter (+/- 583,600)

this (no visited):
test dfs        ... bench:   2,101,213 ns/iter (+/- 877,112)
test dfs_by_ref ... bench:   6,596,894 ns/iter (+/- 1,538,473)
test dfs_by_val ... bench:   7,047,675 ns/iter (+/- 1,221,296)

The speed of the main test is the same as before.
Results show that accessing tree in memory is significantly slower than just generating it on the fly. Tests show that passing State and Action by reference when you have your tree is already stored in memory is tiny bit faster compared to by value, presumably by eliminating clone on the data and due to smaller ptr-& size than (Action, State) tuple.

I have also investigated use of Borrow, Deref to eliminate double references with the predicate and expand functions when using ptr-& types for State but found it impossible to do without introducing another associated type representing non-ptr-& type of State - it resulted in exactly same performance; did LLVM reduced this to same code?
