### PR TITLE
Separated out DFS iterator that populats Action vector as side effect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,10 @@ homepage = "https://github.com/aldanor/chappie"
 
 [dependencies]
 fnv = "*"
+
+[profile.bench]
+opt-level = 3
+#debug = true # for profiling
+debug-assertions = false
+codegen-units = 1
+

--- a/src/search.rs
+++ b/src/search.rs
@@ -37,33 +37,59 @@ pub trait SearchSpace {
 
     fn dfs<G>(&self, start: &Self::State, goal: &G) -> Option<Vec<Self::Action>>
     where G: SearchGoal<Self::State> {
+        let mut actions = Vec::new();
+
         if goal.is_goal(start) {
-            return Some(vec![]);
+            return Some(actions);
         }
 
-        let mut visited = Visited::new();
-        let mut stack = vec![(self.expand(start), None)];
+        self.dfs_iter(&mut actions, start)
+            .find(|ref state| goal.is_goal(state))
+            .map(|_goal| actions)
+    }
 
+    fn dfs_iter<'s, 't>(&'s self, actions: &'t mut Vec<Self::Action>, state: &'s Self::State) -> DfsIter<'s, 't, Self> {
+        DfsIter::new(self, actions, state)
+    }
+}
+
+pub struct DfsIter<'s, 't, S: ?Sized> where S: SearchSpace + 's, <S as SearchSpace>::Action: 't {
+    search_space: &'s S,
+    stack: Vec<S::Iterator>,
+    actions: &'t mut Vec<S::Action>,
+    visited: Visited<S::State>
+}
+
+impl<'s, 't, S: ?Sized> DfsIter<'s, 't, S> where S: SearchSpace + 's {
+    fn new(search_space: &'s S, actions: &'t mut Vec<S::Action>, start: &S::State) -> DfsIter<'s, 't, S> {
+        DfsIter {
+            search_space: search_space,
+            stack: vec![search_space.expand(start)],
+            actions: actions,
+            visited: Visited::new()
+        }
+    }
+}
+
+impl<'s, 't, S: ?Sized> Iterator for DfsIter<'s, 't, S> where S: SearchSpace + 's {
+    type Item = S::State;
+
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
-            let next = match stack.last_mut() {
+            let next = match self.stack.last_mut() {
                 None => return None,
-                Some(&mut (ref mut iter, _)) => iter.next()
+                Some(mut iter) => iter.next()
             };
             if let Some((action, state)) = next {
-                if !visited.insert(&state) {
+                if !self.visited.insert(&state) {
                     continue;
                 }
-                if goal.is_goal(&state) {
-                    return Some(
-                        stack.into_iter()
-                             .filter_map(|(_, a)| a)
-                             .chain(Some(action).into_iter())
-                             .collect()
-                    )
-                }
-                stack.push((self.expand(&state), Some(action)));
+                self.stack.push(self.search_space.expand(&state));
+                self.actions.push(action);
+                return Some(state)
             } else {
-                stack.pop();
+                self.actions.pop();
+                self.stack.pop();
             }
         }
     }
@@ -149,6 +175,40 @@ pub mod tests {
     }
 
     #[test]
+    pub fn test_dfs_simple_iter() {
+        struct TestSearch;
+
+        #[derive(Debug, PartialEq)]
+        enum Dir { Left, Right }
+
+        impl SearchSpace for TestSearch {
+            type State = i32;
+            type Action = Dir;
+            type Iterator = IntoIter<(Self::Action, Self::State)>;
+
+            fn expand(&self, state: &Self::State) -> Self::Iterator {
+                match *state {
+                    0 => vec![(Dir::Left, 1), (Dir::Right, 2)],
+                    1 => vec![(Dir::Left, 3), (Dir::Right, 4)],
+                    2 => vec![(Dir::Left, 2)],
+                    _ => vec![]
+                }.into_iter()
+            }
+        }
+
+        let ts = TestSearch;
+        let mut actions = Vec::new();
+        let goal = 0;
+        let mut dfs = ts.dfs_iter(&mut actions, &goal);
+
+        assert_eq!(dfs.next(), Some(1));
+        assert_eq!(dfs.next(), Some(3));
+        assert_eq!(dfs.next(), Some(4));
+        assert_eq!(dfs.next(), Some(2));
+        assert_eq!(dfs.next(), None);
+    }
+
+    #[test]
     pub fn test_dfs_simple() {
         struct TestSearch;
 
@@ -192,8 +252,8 @@ pub mod tests {
         assert!(g.dfs(&N_NODES, &0).is_none());
         assert!(g.dfs(&0, &N_NODES).is_none());
 
-        for start in (0..N_NODES) {
-            for goal in (0..N_NODES) {
+        for start in 0..N_NODES {
+            for goal in 0..N_NODES {
                 let observer = Observer::new(goal);
                 if let Some(path) = g.dfs(&start, &observer) {
                     let mut state = start;


### PR DESCRIPTION
DfsIter will provide State as it visits tree in depth first order avoiding loops. As side effect it will populate current stack of Actions in provided mutable Vec so shortest path can be accessed after iteration is complete (e.g. goal was found).
This runs as fast as the original implementation.